### PR TITLE
Fix bug in "Case sensitive login fix"

### DIFF
--- a/pkg/api/keystone/keystone.go
+++ b/pkg/api/keystone/keystone.go
@@ -86,6 +86,7 @@ func getNewToken(c *middleware.Context) (string, error) {
 	}
 
 	user, domain := UserDomain(username)
+	// Remove @domain from project name
 	keystoneProject := strings.Replace(project, "@"+domain, "", 1)
 	auth := Auth_data{
 		Username: user,

--- a/pkg/login/keystone.go
+++ b/pkg/login/keystone.go
@@ -8,6 +8,7 @@ import (
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/log"
 	m "github.com/grafana/grafana/pkg/models"
+	"strings"
 )
 
 type keystoneAuther struct {
@@ -69,7 +70,13 @@ func (a *keystoneAuther) authenticate(query *LoginUserQuery) error {
 	}
 	a.token = auth.Token
 	a.domainId = auth.DomainId
-	query.Username = auth.Username // in case the actual username is a different case
+
+	// Make sure we store the username with the same case as Keystone
+	// in case the actual username is a different case
+	userNameDomain := strings.Split(query.Username, "@")
+	userNameDomain[0] = auth.Username
+	query.Username = strings.Join(userNameDomain, "@")
+
 	return nil
 }
 


### PR DESCRIPTION
When correcting the case of the username, the `@domain` part was being dropped.